### PR TITLE
Fix bottle DSL

### DIFF
--- a/Formula/xcodes.rb
+++ b/Formula/xcodes.rb
@@ -6,8 +6,8 @@ class Xcodes < Formula
 
   bottle do
     root_url 'https://github.com/RobotsAndPencils/xcodes/releases/download/0.17.0'
-    cellar :any_skip_relocation
-    sha256 "bd92a58f7a53091d3c40657f82508b277f57e3827aead6eb3f253475854a89b0" => :mojave
+    sha256 cellar: :any_skip_relocation
+    sha256 mojave: "bd92a58f7a53091d3c40657f82508b277f57e3827aead6eb3f253475854a89b0"
   end
 
   def install


### PR DESCRIPTION
Fix following warning which is occurred in my machine.

```
$ brew doctor
Warning: Calling `cellar` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
Please report this issue to the robotsandpencils/made tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/robotsandpencils/homebrew-made/Formula/xcodes.rb:9

Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the robotsandpencils/made tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/robotsandpencils/homebrew-made/Formula/xcodes.rb:10
```