### PR TITLE
Add aria2 as a recommended dependency

### DIFF
--- a/Formula/xcodes.rb
+++ b/Formula/xcodes.rb
@@ -8,6 +8,8 @@ class Xcodes < Formula
     root_url 'https://github.com/RobotsAndPencils/xcodes/releases/download/0.20.0'
     sha256 cellar: :any_skip_relocation, mojave: "acd0717e5083634c472d17d7b041265f34b197164ecfcf513b812d77ff978c6d"
   end
+  
+  depends_on "aria2" => :recommended
 
   def install
     system "make", "install", "prefix=#{prefix}"


### PR DESCRIPTION
For most users, `aria2` is a vast improvement to `xcodes` usage, so I think it should be added as a [recommended dependency](https://docs.brew.sh/Formula-Cookbook#specifying-other-formulae-as-dependencies) to `xcodes` when installed using Homebrew, so it'll be automatically installed with `xcodes` unless the `--without-aria2` flag is used.
 
This also has the added advantage of marking `aria2` as a dependency of `xcodes`, so it will be listed with `brew leaves --installed-as-dependency` and it can be easily deleted if `xcodes` is deleted with `brew autoremove`.

This closes #4.